### PR TITLE
docs(readme): link the project write-up and its video walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 Visualize your Gmail and Google Calendar communication network as an interactive graph. Parse your Gmail and Calendar exports, extract contacts and co-attendees, and explore them through a D3.js force-directed web interface.
 
+**[See it running →](https://yegormishchuk.dev/blog/gmail_project)** — a write-up
+about the project, with a video walkthrough of the graph.
+
 ## Privacy
 
 Everything runs on your machine. The parsers read your local Takeout export and


### PR DESCRIPTION
Adds a link to the project write-up right under the description, so a visitor can see the graph before deciding whether to run the pipeline.

The write-up includes a video walkthrough. Checked the URL resolves: HTTP 200, no redirects.

Placed above **Privacy** rather than in a section further down — it answers the first question someone has about a visualization project, and the fixture route lower in the README is the slower answer to the same question.