### PR TITLE
docs(readme): expand setup guidance and add a license badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Gmail Contact Graph
 
 [![CI](https://github.com/yegormishchuk/gmail-contact-graph/actions/workflows/ci.yml/badge.svg)](https://github.com/yegormishchuk/gmail-contact-graph/actions/workflows/ci.yml)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 Visualize your Gmail and Google Calendar communication network as an interactive graph. Parse your Gmail and Calendar exports, extract contacts and co-attendees, and explore them through a D3.js force-directed web interface.
 
@@ -20,25 +21,164 @@ addresses** — never subjects or message bodies — are sent to the Hugging Fac
 API to classify them as human or automated. Leave `HF_API_KEY` empty and the
 project makes no outbound network requests at all.
 
-## Dependencies
+## Install dependencies
 
-- **Rust 1.87+** — for the mbox and calendar parsers; declared as
-  `rust-version` in each `Cargo.toml`, so an older toolchain fails with a clear
-  message instead of a confusing compile error
-- **Node.js 20.19+** — for the webapp (CI builds on Node 24)
-- **GNU Make** — optional; every step below also lists the plain `cargo` / `npm`
-  commands under a "Without `make`" toggle
+| Dependency | Version | Needed for |
+|---|---|---|
+| **Rust** | 1.87+ | the mbox and calendar parsers |
+| **Node.js** | 20.19+ | the webapp (CI builds on Node 24) |
+| **pkg-config** | any | building the parsers — locates system libraries |
+| **OpenSSL headers** (`libssl-dev`) | any | building the parsers — TLS for the optional Hugging Face calls |
+| **GNU Make** | any | optional — every step below also lists the plain `cargo` / `npm` commands |
+
+`pkg-config` and the OpenSSL development headers are the two that most often
+bite: without them `cargo build` fails partway through with a `native-tls` /
+`openssl-sys` error rather than a missing-dependency message. They are already
+present on macOS (via Homebrew's OpenSSL) and on Windows (the build uses
+Schannel), so in practice this is a Linux prerequisite.
+
+<details>
+<summary>How to install each one</summary>
+
+**Rust 1.87+** — install via [rustup](https://rustup.rs), which is the same on
+every platform:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+```
+
+On Windows, download and run [`rustup-init.exe`](https://rustup.rs) instead.
+Already have Rust? Update it:
+
+```bash
+rustup update stable
+```
+
+Verify with `cargo --version` — it must report 1.87.0 or newer. The version is
+declared as `rust-version` in each `Cargo.toml`, so an older toolchain fails
+with a clear message instead of a confusing compile error.
+
+**Node.js 20.19+** — download the LTS installer from
+[nodejs.org](https://nodejs.org), or use a version manager:
+
+```bash
+# nvm (macOS / Linux)
+nvm install 24
+nvm use 24
+```
+
+```bash
+# Debian / Ubuntu, via NodeSource
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+```bash
+# macOS, via Homebrew
+brew install node
+```
+
+Verify with `node --version`.
+
+**pkg-config and OpenSSL headers** — needed to compile the parsers' TLS stack:
+
+```bash
+# Debian / Ubuntu
+sudo apt-get update
+sudo apt-get install -y pkg-config libssl-dev build-essential
+```
+
+```bash
+# Fedora / RHEL
+sudo dnf install -y pkgconf-pkg-config openssl-devel gcc
+```
+
+```bash
+# Arch
+sudo pacman -S --needed pkgconf openssl base-devel
+```
+
+```bash
+# Alpine
+sudo apk add pkgconf openssl-dev build-base
+```
+
+```bash
+# macOS — Xcode command line tools plus Homebrew OpenSSL
+xcode-select --install
+brew install pkg-config openssl@3
+```
+
+On Windows nothing extra is required: the build links against the system
+Schannel TLS stack, so there are no OpenSSL headers to install.
+
+**GNU Make** — optional, but every command in this README has a `make` form.
+
+```bash
+# Debian / Ubuntu
+sudo apt-get install -y make
+```
+
+```bash
+# macOS — included with the Xcode command line tools
+xcode-select --install
+```
+
+On Windows, `make` comes with [Git for Windows](https://gitforwindows.org) when
+you install the optional Unix tools, or via `choco install make`. If you would
+rather not install it, follow the "Without `make`" toggle in each step.
+
+</details>
 
 ## Quick start
 
-```bash
-git clone <repo-url> gmail-contact-graph
-cd gmail-contact-graph
-cp .env.example .env                          # set USER_EMAIL
+**Start the download first.** Go to [Google Takeout](https://takeout.google.com)
+and request your **Mail** export (and **Calendar**, if you want the calendar
+views). It can take hours to arrive, so kick it off before anything else and set
+the rest up while you wait. Don't want to wait at all? A synthetic mbox ships
+with the parser — jump to [Try it without your own
+mail](#try-it-without-your-own-mail) and you can have a graph on screen in a few
+minutes.
 
-# put your Google Takeout export at data/Email/data.mbox, then:
-cd gmail-mbox-parser      && make process-all
-cd ../gmail-contact-graph && make setup && make run
+Then, one line at a time:
+
+```bash
+git clone https://github.com/yegormishchuk/gmail-contact-graph.git
+```
+
+```bash
+cd gmail-contact-graph
+```
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and set `USER_EMAIL` to your Gmail address.
+
+When the Takeout archive arrives, put the mail export at
+`data/Email/data.mbox`, then parse it:
+
+```bash
+cd gmail-mbox-parser
+```
+
+```bash
+make process-all
+```
+
+Finally, build and start the webapp:
+
+```bash
+cd ../gmail-contact-graph
+```
+
+```bash
+make setup
+```
+
+```bash
+make run
 ```
 
 Open [http://localhost:5000](http://localhost:5000).
@@ -51,12 +191,21 @@ invented messages between made-up addresses, no personal data involved:
 
 ```bash
 cd gmail-mbox-parser
-make process-all USER_EMAIL=you@example.com \
-                 MBOX_DIR=tests/fixtures MBOX_FILE=sample.mbox \
-                 DATA_DIR=../data/demo
+```
 
+```bash
+make process-all USER_EMAIL=you@example.com MBOX_DIR=tests/fixtures MBOX_FILE=sample.mbox DATA_DIR=../data/demo
+```
+
+```bash
 cd ../gmail-contact-graph
+```
+
+```bash
 make setup
+```
+
+```bash
 make run CONTACTS_DB_FILE=../data/demo/contacts.db
 ```
 


### PR DESCRIPTION
Quick start now leads with the Takeout request, since the export can take hours to arrive, and points at the bundled fixture for anyone who does not want to wait. Its commands are one per block with a real clone URL, so each can be pasted into a shell without && or line continuations.

The dependency list becomes an Install dependencies chapter with a collapsible per-platform guide. It adds pkg-config and libssl-dev, which a tester found missing: reqwest keeps its default-tls feature, so on Linux the parsers link against the system OpenSSL and fail in openssl-sys without them.