### PR TITLE
feat(docker): containerize the parsers and webapp

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# Keeps the build context small. data/ alone is ~2.7 GB and the three Rust
+# target/ directories add another ~2.2 GB.
+#
+# Note: docker/parsers.Dockerfile.dockerignore and
+# docker/webapp.Dockerfile.dockerignore take precedence over this file for
+# their respective builds; this one is the fallback for any other build.
+data/
+**/target/
+**/node_modules/
+**/dist/
+.git/
+.env
+*.mbox

--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,14 @@ HF_API_KEY=
 HF_MODEL=meta-llama/Llama-3.1-8B-Instruct
 HF_BATCH_SIZE=50
 HF_TIMEOUT=120
+
+# ---- Docker (optional; see "Run with Docker" in README.md) ----
+# Which mbox in data/Email/ to parse. fill_db takes exactly one file and
+# rebuilds the mails table from it, so there is no globbing.
+MBOX_FILE=data.mbox
+
+# Linux/macOS only: make container-written files belong to you instead of root.
+# These are shell variables, not exported env vars, so Compose only sees them
+# from here (or after an explicit `export UID GID`). Ignored on Windows/WSL2.
+#UID=1000
+#GID=1000

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,12 @@
 # same file parses differently on Windows than it does on Linux and macOS.
 *.mbox -text
 *.ics  -text
+
+# Container files must keep LF regardless of the checkout platform. A CRLF
+# shebang makes the kernel look for an interpreter literally named "/bin/sh\r"
+# and the container dies with an unhelpful "no such file or directory".
+*.sh              text eol=lf
+*.Dockerfile      text eol=lf
+docker-compose.yml text eol=lf
+.dockerignore     text eol=lf
+*.dockerignore    text eol=lf

--- a/README.md
+++ b/README.md
@@ -183,6 +183,162 @@ make run
 
 Open [http://localhost:5000](http://localhost:5000).
 
+## Run with Docker
+
+No Rust, no Node, no `make` — just Docker (with Compose v2.24+). The native
+workflow above stays the primary, fully supported path; this is an alternative.
+
+**1. Configure.**
+
+```bash
+cp .env.example .env
+```
+
+Open `.env` and set `USER_EMAIL`.
+
+**2. Put your exports in place.**
+
+```
+data/Email/data.mbox        <- your Gmail .mbox export
+data/Calendar/*.ics         <- your Google Calendar exports
+```
+
+A differently named export? Either rename it to `data.mbox` or set
+`MBOX_FILE=my_export.mbox` in `.env`. One file per run — see [Why only one mbox
+at a time](#why-only-one-mbox-at-a-time).
+
+**3. Run everything.**
+
+```bash
+./docker/pipeline.sh
+```
+
+That parses your mail, generates the rankings, imports the calendar, and starts
+the webapp on [http://127.0.0.1:5000](http://127.0.0.1:5000). The first run
+builds the images, which takes several minutes — the parsers compile SQLite from
+source. Later runs reuse the cache.
+
+Want to see it work in a few seconds first? Point it at the synthetic fixture:
+
+```bash
+cp gmail-mbox-parser/tests/fixtures/sample.mbox data/Email/
+```
+
+```bash
+USER_EMAIL=you@example.com MBOX_FILE=sample.mbox DATA_DIR=./data/demo ./docker/pipeline.sh
+```
+
+That builds a seven-contact graph in `data/demo/`, leaving any real
+`data/contacts.db` alone — drop the directory when you are done. `USER_EMAIL`
+matters here: the fixture's invented addresses only resolve into a graph when
+you are `you@example.com`, and leave `HF_API_KEY` empty as the native demo
+above explains.
+
+### Day to day
+
+Once the database exists, you only need the webapp:
+
+```bash
+docker compose up -d webapp     # start
+docker compose stop webapp      # stop
+docker compose logs -f webapp   # follow the logs
+```
+
+Re-run `./docker/pipeline.sh` after a fresh Takeout export. If nothing changed
+it says so and skips the slow part; `FORCE_REPARSE=1 ./docker/pipeline.sh`
+re-parses anyway.
+
+### The one rule: don't parse while the webapp is running
+
+The webapp loads the whole database into memory at startup, and every time you
+exclude a contact it writes that in-memory copy back over the file. A webapp
+that started *before* a parse will therefore overwrite the freshly parsed
+database with its stale copy — silently, at the moment you next click something.
+
+`./docker/pipeline.sh` handles this: it stops the webapp first and starts it
+again afterwards. Run the parser by hand while the webapp is up and it refuses:
+
+```
+ERROR: the webapp container is running and would overwrite this parse.
+Stop it first:  docker compose stop webapp
+```
+
+For the same reason, a webapp already running when you re-parse keeps serving
+the old graph until `docker compose restart webapp` — the database is read once,
+at startup.
+
+### Running the steps by hand
+
+`./docker/pipeline.sh` is exactly these three commands:
+
+```bash
+docker compose stop webapp
+```
+
+```bash
+docker compose --profile parse up --abort-on-container-failure parser calendar
+```
+
+```bash
+docker compose up -d webapp
+```
+
+Naming `parser calendar` explicitly is deliberate: `docker compose --profile
+parse up` without service names would also start the webapp, which is the
+situation the rule above warns about. To re-import only the calendar, run the
+same three commands with `calendar` alone in the middle one.
+
+### Why only one mbox at a time
+
+The parser rebuilds the `mails` table from scratch on every run, so pointing it
+at several `.mbox` files would leave you with only the last one's data. It reads
+exactly one file — `MBOX_FILE`, default `data.mbox`. If it is missing, the error
+lists what is actually in `data/Email/`.
+
+### Docker settings
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `USER_EMAIL` | — | Required. Your address; the "you" node. |
+| `MBOX_FILE` | `data.mbox` | Which file in `data/Email/` to parse. |
+| `PORT` | `5000` | Host and container port, kept in sync automatically. |
+| `DATA_DIR` | `./data` | Where the exports and database live. |
+| `FORCE_REPARSE` | `0` | `1` re-parses even when nothing changed. |
+| `HF_API_KEY` | empty | Optional AI spam filtering (non-deterministic). |
+
+The port is published on `127.0.0.1` only, so the container is no more exposed
+than the native server is.
+
+**Linux and macOS — file ownership.** Containers run as UID 1000 by default, so
+files the parser writes may not belong to you. `UID`/`GID` are shell variables
+rather than environment variables, so Compose cannot see them unless you say so:
+
+```bash
+echo "UID=$(id -u)" >> .env && echo "GID=$(id -g)" >> .env
+```
+
+Ignored on Windows.
+
+**Windows — keep the repo inside WSL2.** `data/` runs to a couple of gigabytes,
+and Docker Desktop reaches Windows paths (`C:\...`) through a translation layer
+that makes large sequential reads and SQLite noticeably slower. Clone into the
+WSL2 filesystem (`\\wsl$\...`) rather than working under `/mnt/c/...`.
+
+**When something is wrong.**
+
+```bash
+docker compose ps -a                  # what ran, and did it exit 0
+docker compose logs parser            # why the parse failed
+docker compose --profile parse down   # stop and remove everything
+```
+
+Use `--profile parse` on `down` as well: a plain `docker compose down` only
+touches the default profile, so stopped parser containers stay listed in
+`docker compose ps -a`.
+
+No calendar export? The calendar step reports that it found no `.ics` files and
+exits successfully — the mail graph does not depend on it.
+
 ## Try it without your own mail
 
 A Takeout export takes hours to arrive. To see the graph before then, build the

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ Open [http://localhost:5000](http://localhost:5000).
 
 ## Run with Docker
 
-No Rust, no Node, no `make` — just Docker (with Compose v2.24+). The native
+No Rust, no Node, no `make` — just Docker (with Compose v2.27+, which is where
+`up --abort-on-container-failure` arrived). The native
 workflow above stays the primary, fully supported path; this is an alternative.
 
 **1. Configure.**
@@ -233,6 +234,18 @@ mkdir -p data/demo/Email && cp gmail-mbox-parser/tests/fixtures/sample.mbox data
 USER_EMAIL=you@example.com MBOX_FILE=sample.mbox DATA_DIR=./data/demo ./docker/pipeline.sh
 ```
 
+Both of those are Git Bash lines too, for the same reason as the script itself.
+The PowerShell equivalent — the `VAR=value cmd` prefix has no PowerShell form,
+so the settings go in the environment first:
+
+```powershell
+New-Item -ItemType Directory -Force data/demo/Email
+Copy-Item gmail-mbox-parser/tests/fixtures/sample.mbox data/demo/Email/
+$env:USER_EMAIL = "you@example.com"; $env:MBOX_FILE = "sample.mbox"; $env:DATA_DIR = "./data/demo"
+docker compose --profile parse up --abort-on-container-failure parser calendar
+docker compose up -d webapp
+```
+
 That builds a seven-contact graph in `data/demo/`, leaving any real
 `data/contacts.db` alone — drop the directory when you are done. The fixture
 goes under `data/demo/Email/` rather than `data/Email/` because `DATA_DIR` is
@@ -254,6 +267,15 @@ docker compose logs -f webapp   # follow the logs
 Re-run `./docker/pipeline.sh` after a fresh Takeout export. If nothing changed
 it says so and skips the slow part; `FORCE_REPARSE=1 ./docker/pipeline.sh`
 re-parses anyway.
+
+After a `git pull` or an edit to the parser or webapp sources, rebuild the
+images — `docker compose up` reuses whatever image is already there and will
+otherwise keep running the old code without saying so:
+
+```bash
+docker compose --profile parse build   # both images
+docker compose up -d --build webapp    # or just the webapp, rebuilt in place
+```
 
 ### The one rule: don't parse while the webapp is running
 
@@ -293,7 +315,10 @@ docker compose up -d webapp
 Naming `parser calendar` explicitly is deliberate: `docker compose --profile
 parse up` without service names would also start the webapp, which is the
 situation the rule above warns about. To re-import only the calendar, run the
-same three commands with `calendar` alone in the middle one.
+same three commands with `calendar` alone in the middle one — the mail parser
+still starts, because the calendar step depends on it having completed, but it
+finds the database up to date and exits immediately. Don't combine that with
+`FORCE_REPARSE=1`, which re-parses the whole mbox as well.
 
 ### Why only one mbox at a time
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ three commands it wraps instead — see
 Want to see it work in a few seconds first? Point it at the synthetic fixture:
 
 ```bash
-cp gmail-mbox-parser/tests/fixtures/sample.mbox data/Email/
+mkdir -p data/demo/Email && cp gmail-mbox-parser/tests/fixtures/sample.mbox data/demo/Email/
 ```
 
 ```bash
@@ -234,10 +234,12 @@ USER_EMAIL=you@example.com MBOX_FILE=sample.mbox DATA_DIR=./data/demo ./docker/p
 ```
 
 That builds a seven-contact graph in `data/demo/`, leaving any real
-`data/contacts.db` alone — drop the directory when you are done. `USER_EMAIL`
-matters here: the fixture's invented addresses only resolve into a graph when
-you are `you@example.com`, and leave `HF_API_KEY` empty as the native demo
-above explains.
+`data/contacts.db` alone — drop the directory when you are done. The fixture
+goes under `data/demo/Email/` rather than `data/Email/` because `DATA_DIR` is
+what gets mounted: the parser always reads `$DATA_DIR/Email/$MBOX_FILE`.
+`USER_EMAIL` matters here: the fixture's invented addresses only resolve into a
+graph when you are `you@example.com`, and leave `HF_API_KEY` empty as the
+native demo above explains.
 
 ### Day to day
 

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ the webapp on [http://127.0.0.1:5000](http://127.0.0.1:5000). The first run
 builds the images, which takes several minutes — the parsers compile SQLite from
 source. Later runs reuse the cache.
 
+On Windows the script needs a POSIX shell, so run it from **Git Bash** rather
+than PowerShell (`sh` is not on PowerShell's PATH). From PowerShell, run the
+three commands it wraps instead — see
+[Running the steps by hand](#running-the-steps-by-hand).
+
 Want to see it work in a few seconds first? Point it at the synthetic fixture:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,12 +40,17 @@ services:
       # so without these two lines a shell override is silently ignored.
       # Compose interpolates the right-hand side from the shell first and from
       # .env second, and an empty value is indistinguishable from unset to the
-      # entrypoint's ${VAR:-default}. DATA_DIR is deliberately NOT passed
-      # through: it selects the host directory to mount, and inside the
-      # container the data always lives at /app/data.
+      # entrypoint's ${VAR:-default}.
       MBOX_FILE: "${MBOX_FILE:-}"
       FORCE_REPARSE: "${FORCE_REPARSE:-}"
       USER_EMAIL: "${USER_EMAIL:-}"
+      # Pinned, NOT passed through. DATA_DIR selects the HOST directory to
+      # mount (see volumes below); inside the container the data always lives
+      # at /app/data. It has to be pinned rather than simply left out: a
+      # DATA_DIR in .env reaches the container through env_file, and the
+      # entrypoint would then look for the data at a host path that does not
+      # exist here -- "ERROR: ./data/demo is not mounted" on a correct mount.
+      DATA_DIR: /app/data
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ${DATA_DIR:-./data}:/app/data
@@ -69,6 +74,8 @@ services:
       # See the parser service: host environment does not reach containers on
       # its own, and the Makefiles accept USER_EMAIL on the command line.
       USER_EMAIL: "${USER_EMAIL:-}"
+      # Pinned for the same reason as the parser service.
+      DATA_DIR: /app/data
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ${DATA_DIR:-./data}:/app/data
@@ -87,6 +94,20 @@ services:
       # on the host, so the mailbox is not exposed to the network.
       HOST: "0.0.0.0"
       USER_EMAIL: "${USER_EMAIL:-}"
+      # Same passthrough reason as the parser service: env_file reaches inside
+      # the container but the host shell does not, while the `ports` mapping
+      # below is interpolated from the shell first. Without this line
+      # `PORT=5055 docker compose up -d webapp` publishes 5055 while the server
+      # still binds 5000, and the healthcheck -- which defaults to 5000 too --
+      # reports healthy about a port nothing can reach.
+      # Empty is safe: config.ts reads `process.env.PORT || '5000'`.
+      PORT: "${PORT:-}"
+      # Pinned for the same reason as the parser service: a DATA_DIR in .env
+      # would otherwise reach the entrypoint, which would look for contacts.db
+      # under a host path and report it missing on a perfectly good mount.
+      # config.ts derives its own path from the directory layout and ignores
+      # this variable; the entrypoint's lock file does not.
+      DATA_DIR: /app/data
     # Interpolated from the root .env by compose itself (a different mechanism
     # from env_file, which only reaches inside the container). Keeps the
     # published port in sync with the PORT the server actually binds.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,7 +98,11 @@ services:
       - ${DATA_DIR:-./data}:/app/data
     healthcheck:
       # node:22-bookworm-slim has neither curl nor wget; Node 22 has fetch.
-      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||5000)+'/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      #
+      # /api/contacts, not /api/health: the latter answers 200 without touching
+      # a single table, so a database left half-built by a failed parse still
+      # reports healthy while every real endpoint returns 500.
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||5000)+'/api/contacts').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,18 @@ services:
     env_file:
       - path: .env
         required: false
+    environment:
+      # Passthrough so `MBOX_FILE=x ./docker/pipeline.sh` works from the shell.
+      # env_file only reaches inside the container; host environment does not,
+      # so without these two lines a shell override is silently ignored.
+      # Compose interpolates the right-hand side from the shell first and from
+      # .env second, and an empty value is indistinguishable from unset to the
+      # entrypoint's ${VAR:-default}. DATA_DIR is deliberately NOT passed
+      # through: it selects the host directory to mount, and inside the
+      # container the data always lives at /app/data.
+      MBOX_FILE: "${MBOX_FILE:-}"
+      FORCE_REPARSE: "${FORCE_REPARSE:-}"
+      USER_EMAIL: "${USER_EMAIL:-}"
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ${DATA_DIR:-./data}:/app/data
@@ -53,6 +65,10 @@ services:
     env_file:
       - path: .env
         required: false
+    environment:
+      # See the parser service: host environment does not reach containers on
+      # its own, and the Makefiles accept USER_EMAIL on the command line.
+      USER_EMAIL: "${USER_EMAIL:-}"
     user: "${UID:-1000}:${GID:-1000}"
     volumes:
       - ${DATA_DIR:-./data}:/app/data
@@ -70,6 +86,7 @@ services:
       # outside the container. The published port below is still loopback-only
       # on the host, so the mailbox is not exposed to the network.
       HOST: "0.0.0.0"
+      USER_EMAIL: "${USER_EMAIL:-}"
     # Interpolated from the root .env by compose itself (a different mechanism
     # from env_file, which only reaches inside the container). Keeps the
     # published port in sync with the PORT the server actually binds.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,88 @@
+# Two ways to run this stack.
+#
+#   ./docker/pipeline.sh          -- parse everything, then serve (the usual one)
+#   docker compose up -d webapp   -- serve an already-parsed database
+#
+# The pipeline is a script rather than a single `docker compose up` because the
+# webapp must be STOPPED while the database is rebuilt and started afterwards:
+# it holds the whole database in memory and writes it back wholesale on any
+# exclude-contact action (server/src/db/index.ts:30-34), so a webapp left
+# running across a parse silently overwrites the fresh data with its snapshot.
+#
+# The parse services sit behind a profile rather than depends_on/required:false
+# -- `required: false` means "do not fail if absent", not "never start".
+# Running them by hand means naming them explicitly:
+#
+#   docker compose stop webapp
+#   docker compose --profile parse up --abort-on-container-failure parser calendar
+#   docker compose up -d webapp
+#
+# `--profile parse up` WITHOUT service names would also start the webapp (it is
+# in the default profile), which is exactly the situation above.
+# --abort-on-container-failure matters too: without it `up` exits 0 even when a
+# one-shot service failed.
+
+services:
+  parser:
+    profiles: ["parse"]
+    build:
+      context: .
+      dockerfile: docker/parsers.Dockerfile
+    image: gmail-contact-graph/parsers
+    command: ["mail"]
+    restart: "no"
+    env_file:
+      - path: .env
+        required: false
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      - ${DATA_DIR:-./data}:/app/data
+
+  calendar:
+    profiles: ["parse"]
+    build:
+      context: .
+      dockerfile: docker/parsers.Dockerfile
+    image: gmail-contact-graph/parsers
+    command: ["calendar"]
+    restart: "no"
+    # Both write the same SQLite file, so they must not run concurrently.
+    depends_on:
+      parser:
+        condition: service_completed_successfully
+    env_file:
+      - path: .env
+        required: false
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      - ${DATA_DIR:-./data}:/app/data
+
+  webapp:
+    build:
+      context: .
+      dockerfile: docker/webapp.Dockerfile
+    image: gmail-contact-graph/webapp
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      # config.ts defaults to 127.0.0.1, which would be unreachable from
+      # outside the container. The published port below is still loopback-only
+      # on the host, so the mailbox is not exposed to the network.
+      HOST: "0.0.0.0"
+    # Interpolated from the root .env by compose itself (a different mechanism
+    # from env_file, which only reaches inside the container). Keeps the
+    # published port in sync with the PORT the server actually binds.
+    ports:
+      - "127.0.0.1:${PORT:-5000}:${PORT:-5000}"
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      # Read-write on purpose: the exclude-contact endpoints write contacts.db.
+      - ${DATA_DIR:-./data}:/app/data
+    healthcheck:
+      # node:22-bookworm-slim has neither curl nor wget; Node 22 has fetch.
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:'+(process.env.PORT||5000)+'/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s

--- a/docker/parse-entrypoint.sh
+++ b/docker/parse-entrypoint.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# Container-side equivalent of the `fill-db`, `rankings` and `fill-events` make
+# targets. Variable names and defaults deliberately mirror
+# gmail-mbox-parser/Makefile and calendar-parser/Makefile -- if you change a
+# default there, change it here too.
+#
+# Usage: parse-entrypoint.sh mail|calendar
+set -eu
+
+DATA_DIR="${DATA_DIR:-/app/data}"
+MBOX_DIR="${MBOX_DIR:-$DATA_DIR/Email}"
+MBOX_FILE="${MBOX_FILE:-data.mbox}"
+RANKINGS_DIR="${RANKINGS_DIR:-$DATA_DIR/rankings}"
+DB_PATH="${DB_PATH:-$DATA_DIR/contacts.db}"
+ICS_FILES="${ICS_FILES:-$DATA_DIR/Calendar}"
+STAMP="$DATA_DIR/.parse-stamp"
+LOCK="$DATA_DIR/.webapp.lock"
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+[ -n "${USER_EMAIL:-}" ] || die "USER_EMAIL is not set.
+Copy .env.example to .env in the project root and fill in USER_EMAIL,
+or pass it on the command line: USER_EMAIL=you@gmail.com docker compose ..."
+
+[ -d "$DATA_DIR" ] || die "$DATA_DIR is not mounted."
+
+# The webapp reads contacts.db into memory once at startup and writes the WHOLE
+# file back on every exclude-contact action (server/src/db/index.ts:30-34).
+# A webapp started before this parse would silently overwrite the fresh
+# database with its stale snapshot.
+if [ -e "$LOCK" ]; then
+    die "the webapp container is running and would overwrite this parse.
+Stop it first:  docker compose stop webapp
+(If a hard-killed container left the lock behind, delete $LOCK.)"
+fi
+
+mkdir -p "$RANKINGS_DIR"
+
+case "${1:-}" in
+  mail)
+    MBOX_PATH="$MBOX_DIR/$MBOX_FILE"
+    if [ ! -f "$MBOX_PATH" ]; then
+        echo "ERROR: mbox not found: $MBOX_PATH" >&2
+        echo "MBOX_FILE=$MBOX_FILE. Files present in $MBOX_DIR:" >&2
+        ls -1 "$MBOX_DIR" >&2 2>/dev/null || echo "  (directory is empty or missing)" >&2
+        echo "Set MBOX_FILE in .env to one of them." >&2
+        # fill_db takes exactly ONE mbox and starts with DROP TABLE IF EXISTS
+        # mails (fill_db/db.rs:23), so looping over *.mbox would silently keep
+        # only the last file. One file per run, on purpose.
+        exit 1
+    fi
+
+    # Idempotency stamp. NOT "does contacts.db exist": that skips forever after
+    # a crash mid-parse, ignores a freshly exported mbox, and clashes with the
+    # hand-restored contacts.db.bak files already in data/. Signature is
+    # name+size+mtime+email -- sha256 of a 2.7 GB mbox would cost 10-60s on
+    # every start, including no-op ones.
+    SIG="$MBOX_FILE $(stat -c '%s %Y' "$MBOX_PATH") $USER_EMAIL"
+    if [ "${FORCE_REPARSE:-0}" != "1" ] && [ -f "$STAMP" ] && [ "$(cat "$STAMP")" = "$SIG" ]; then
+        echo "Database is up to date for $MBOX_FILE -- skipping. FORCE_REPARSE=1 to override."
+        exit 0
+    fi
+
+    echo "Parsing $MBOX_PATH as $USER_EMAIL -> $DB_PATH"
+    fill_db "$MBOX_PATH" "$USER_EMAIL" "$DB_PATH"
+    echo "Generating rankings -> $RANKINGS_DIR"
+    generate_rankings "$DB_PATH" "$RANKINGS_DIR"
+
+    # Written only after every step succeeded. `set -eu` above is what makes
+    # that true: without it a failing fill_db would be ignored, the script
+    # would exit 0, and compose would report service_completed_successfully.
+    printf '%s' "$SIG" > "$STAMP"
+    echo "Done."
+    ;;
+
+  calendar)
+    [ -f "$DB_PATH" ] || die "$DB_PATH does not exist. Run the mail parser first."
+    echo "Filling events from $ICS_FILES -> $DB_PATH"
+    # fill_events accepts a directory, unlike fill_db.
+    fill_events "$ICS_FILES" --db "$DB_PATH" --user-email "$USER_EMAIL"
+    echo "Done."
+    ;;
+
+  *)
+    die "usage: parse-entrypoint.sh mail|calendar (got '${1:-}')"
+    ;;
+esac

--- a/docker/parse-entrypoint.sh
+++ b/docker/parse-entrypoint.sh
@@ -75,6 +75,17 @@ case "${1:-}" in
 
   calendar)
     [ -f "$DB_PATH" ] || die "$DB_PATH does not exist. Run the mail parser first."
+
+    # The calendar step is optional (README: "5. (Optional) Parse calendar
+    # events"), so an empty or absent Calendar directory is a skip, not a
+    # failure. fill_events itself exits 1 in that case, which would abort the
+    # whole pipeline for everyone who never exported a calendar.
+    if [ -d "$ICS_FILES" ] && [ -z "$(find "$ICS_FILES" -maxdepth 1 -iname '*.ics' -print -quit)" ]; then
+        echo "No .ics files in $ICS_FILES -- skipping the calendar step."
+        echo "Export Google Calendar into that directory to enable the calendar views."
+        exit 0
+    fi
+
     echo "Filling events from $ICS_FILES -> $DB_PATH"
     # fill_events accepts a directory, unlike fill_db.
     fill_events "$ICS_FILES" --db "$DB_PATH" --user-email "$USER_EMAIL"

--- a/docker/parse-entrypoint.sh
+++ b/docker/parse-entrypoint.sh
@@ -61,6 +61,14 @@ case "${1:-}" in
         exit 0
     fi
 
+    # Drop the stamp BEFORE the first destructive step. fill_db starts with
+    # DROP TABLE IF EXISTS mails (fill_db/db.rs:23), so from here on the
+    # database on disk is incomplete until the run finishes. A stamp left in
+    # place would survive a failure and -- if it happened to match this same
+    # signature from an earlier successful run -- make the next run report
+    # "up to date" and start the webapp on a half-built database.
+    rm -f "$STAMP"
+
     echo "Parsing $MBOX_PATH as $USER_EMAIL -> $DB_PATH"
     fill_db "$MBOX_PATH" "$USER_EMAIL" "$DB_PATH"
     echo "Generating rankings -> $RANKINGS_DIR"
@@ -80,7 +88,10 @@ case "${1:-}" in
     # events"), so an empty or absent Calendar directory is a skip, not a
     # failure. fill_events itself exits 1 in that case, which would abort the
     # whole pipeline for everyone who never exported a calendar.
-    if [ -d "$ICS_FILES" ] && [ -z "$(find "$ICS_FILES" -maxdepth 1 -iname '*.ics' -print -quit)" ]; then
+    # Absent counts as empty: a fresh DATA_DIR has no Calendar directory at
+    # all, and requiring -d here made that case fall through to fill_events,
+    # which exits 1 and aborts the pipeline before the webapp ever starts.
+    if [ ! -d "$ICS_FILES" ] || [ -z "$(find "$ICS_FILES" -maxdepth 1 -iname '*.ics' -print -quit)" ]; then
         echo "No .ics files in $ICS_FILES -- skipping the calendar step."
         echo "Export Google Calendar into that directory to enable the calendar views."
         exit 0

--- a/docker/parsers.Dockerfile
+++ b/docker/parsers.Dockerfile
@@ -1,0 +1,86 @@
+# syntax=docker/dockerfile:1
+
+# Three independent Cargo packages, each with its own Cargo.lock and target/:
+#   gmail-mbox-parser        -> fill_db            (has a lib target too)
+#   gmail-mbox-parser/tools  -> generate_rankings  (package "ranking_tools")
+#   calendar-parser          -> fill_events
+#
+# Dependency compilation is cached in IMAGE LAYERS via the manifest-stub
+# pattern, not in a --mount=type=cache on target/. A cache mount lives only for
+# the duration of its RUN and lands in no layer, so cache-mounting target/ would
+# give a colleague, a cold clone or CI no cache at all. rusqlite/bundled
+# compiles SQLite from C and the release profile sets lto=true with
+# codegen-units=1, so a cold dependency build is minutes -- worth caching
+# properly. The registry cache mount below only saves crates.io downloads.
+FROM rust:1.87-bookworm AS builder
+
+# reqwest 0.12 default features resolve to native-tls -> openssl-sys, which
+# links the SYSTEM OpenSSL. Without these the build fails inside openssl-sys.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        pkg-config libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /out
+
+# ---------- fill_db ----------
+WORKDIR /build/gmail-mbox-parser
+COPY gmail-mbox-parser/Cargo.toml gmail-mbox-parser/Cargo.lock ./
+RUN mkdir -p src/bin/fill_db \
+    && : > src/lib.rs \
+    && echo 'fn main(){}' > src/bin/fill_db/main.rs
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    cargo build --release --bin fill_db
+COPY gmail-mbox-parser/src ./src
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    touch src/lib.rs src/bin/fill_db/main.rs \
+    && cargo build --release --bin fill_db \
+    && cp target/release/fill_db /out/fill_db
+
+# ---------- generate_rankings ----------
+WORKDIR /build/gmail-mbox-parser/tools
+COPY gmail-mbox-parser/tools/Cargo.toml gmail-mbox-parser/tools/Cargo.lock ./
+RUN mkdir -p src && echo 'fn main(){}' > src/generate_rankings.rs
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    cargo build --release --bin generate_rankings
+COPY gmail-mbox-parser/tools/src ./src
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    touch src/generate_rankings.rs \
+    && cargo build --release --bin generate_rankings \
+    && cp target/release/generate_rankings /out/generate_rankings
+
+# ---------- fill_events ----------
+WORKDIR /build/calendar-parser
+COPY calendar-parser/Cargo.toml calendar-parser/Cargo.lock ./
+RUN mkdir -p src/bin/fill_events && echo 'fn main(){}' > src/bin/fill_events/main.rs
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    cargo build --release --bin fill_events
+COPY calendar-parser/src ./src
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    touch src/bin/fill_events/main.rs \
+    && cargo build --release --bin fill_events \
+    && cp target/release/fill_events /out/fill_events
+
+# Runtime MUST stay on bookworm -- the same Debian release as the builder above.
+# trixie or alpine gives "GLIBC_2.xx not found" / musl breakage.
+FROM debian:bookworm-slim AS runtime
+
+# ca-certificates: HTTPS to the Hugging Face API (optional spam pass).
+# libssl3: the native-tls/openssl-sys dynamic link noted above. Without it the
+# binary dies with "error while loading shared libraries: libssl.so.3".
+# rusqlite's bundled SQLite is static and needs nothing.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /out/ /usr/local/bin/
+COPY docker/parse-entrypoint.sh /usr/local/bin/parse-entrypoint.sh
+RUN chmod +x /usr/local/bin/parse-entrypoint.sh
+
+# fill_db and fill_events both call dotenvy::from_path("../.env") at startup
+# (fill_db/main.rs:51, fill_events/main.rs:28). With WORKDIR /app/run that
+# resolves to /app/.env, which is never created or mounted, so the load fails
+# silently and env_file stays the single source of configuration. Do NOT bind
+# mount .env at /app -- it would become a second, higher-precedence source.
+WORKDIR /app/run
+
+ENTRYPOINT ["/usr/local/bin/parse-entrypoint.sh"]

--- a/docker/parsers.Dockerfile
+++ b/docker/parsers.Dockerfile
@@ -83,4 +83,12 @@ RUN chmod +x /usr/local/bin/parse-entrypoint.sh
 # mount .env at /app -- it would become a second, higher-precedence source.
 WORKDIR /app/run
 
+# Numeric, not a named user: debian:bookworm-slim has no account at 1000, and
+# the id is what matters -- it matches the compose `user:` default, so a plain
+# `docker run` of this image behaves like the compose services rather than
+# writing into the mounted data directory as root. Compose still overrides it
+# with UID/GID from .env where those are set.
+RUN chown 1000:1000 /app/run
+USER 1000:1000
+
 ENTRYPOINT ["/usr/local/bin/parse-entrypoint.sh"]

--- a/docker/parsers.Dockerfile.dockerignore
+++ b/docker/parsers.Dockerfile.dockerignore
@@ -1,0 +1,12 @@
+# BuildKit reads <dockerfile-path>.dockerignore in preference to the root
+# .dockerignore, so this list is exhaustive on its own: exclude everything,
+# then re-include only what the Rust build actually needs.
+*
+!gmail-mbox-parser
+!calendar-parser
+!docker/parse-entrypoint.sh
+gmail-mbox-parser/target
+gmail-mbox-parser/tools/target
+gmail-mbox-parser/data
+calendar-parser/target
+**/.git

--- a/docker/pipeline.sh
+++ b/docker/pipeline.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# The three-step pipeline as one command:
+#   stop the webapp -> parse mail + calendar -> start the webapp.
+#
+# The stop/start bracket is mandatory, not cosmetic: the webapp holds the whole
+# database in memory and writes it back wholesale on any exclude-contact action
+# (server/src/db/index.ts:30-34), so a webapp left running across a parse
+# silently overwrites the fresh database with its stale snapshot.
+set -eu
+cd "$(dirname "$0")/.."
+
+echo "==> Stopping the webapp (it must not run while the database is rebuilt)"
+docker compose stop webapp
+
+echo "==> Parsing mail and calendar"
+docker compose --profile parse up --abort-on-container-failure parser calendar
+
+echo "==> Starting the webapp"
+docker compose up -d webapp
+
+PORT="${PORT:-5000}"
+echo ""
+echo "Ready: http://127.0.0.1:${PORT}"

--- a/docker/webapp-entrypoint.sh
+++ b/docker/webapp-entrypoint.sh
@@ -22,12 +22,21 @@ if [ ! -f "$DB_FILE" ]; then
 fi
 
 cleanup() { rm -f "$LOCK"; }
+# EXIT, not just the end of the script: under `set -e` a server that dies with
+# a non-zero status aborts the script at the `wait` below, and a cleanup call
+# placed after it would never run. The lock left behind then makes every later
+# parse refuse with "the webapp container is running" when nothing is.
+trap cleanup EXIT
+# cleanup again here rather than relying on the EXIT trap: whether a shell runs
+# its EXIT trap on the way out of a signal handler varies between shells, and
+# rm -f twice costs nothing.
 trap 'cleanup; [ -n "${pid:-}" ] && kill -TERM "$pid" 2>/dev/null; exit 0' TERM INT
 
 echo "$$" > "$LOCK"
 node dist/index.js &
 pid=$!
-wait "$pid"
-status=$?
-cleanup
+# `|| status=$?` keeps `set -e` from swallowing the exit status here; the EXIT
+# trap releases the lock either way.
+status=0
+wait "$pid" || status=$?
 exit "$status"

--- a/docker/webapp-entrypoint.sh
+++ b/docker/webapp-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Holds /app/data/.webapp.lock for as long as the server runs, so the parser
+# entrypoint can refuse to overwrite the database underneath a live webapp
+# (see docker/parse-entrypoint.sh and server/src/db/index.ts:30-34).
+set -eu
+
+DATA_DIR="${DATA_DIR:-/app/data}"
+LOCK="$DATA_DIR/.webapp.lock"
+
+if [ -z "${USER_EMAIL:-}" ]; then
+    echo "ERROR: USER_EMAIL is not set." >&2
+    echo "Copy .env.example to .env in the project root and fill in USER_EMAIL." >&2
+    exit 1
+fi
+
+DB_FILE="${CONTACTS_DB_FILE:-$DATA_DIR/contacts.db}"
+if [ ! -f "$DB_FILE" ]; then
+    echo "ERROR: $DB_FILE not found. Run the parsers first:" >&2
+    echo "  ./docker/pipeline.sh" >&2
+    echo "or: docker compose --profile parse up --abort-on-container-failure parser calendar" >&2
+    exit 1
+fi
+
+cleanup() { rm -f "$LOCK"; }
+trap 'cleanup; [ -n "${pid:-}" ] && kill -TERM "$pid" 2>/dev/null; exit 0' TERM INT
+
+echo "$$" > "$LOCK"
+node dist/index.js &
+pid=$!
+wait "$pid"
+status=$?
+cleanup
+exit "$status"

--- a/docker/webapp.Dockerfile
+++ b/docker/webapp.Dockerfile
@@ -31,6 +31,12 @@ RUN npm ci --omit=dev
 
 FROM node:22-bookworm-slim AS runtime
 
+# Nothing in this codebase branches on NODE_ENV, but Express does: without it
+# the app runs in development mode, which serves full stack traces on errors
+# and skips the view/etag caching. Only in this stage -- the build stages need
+# the dev dependencies that `npm ci` would otherwise skip.
+ENV NODE_ENV=production
+
 # The directory layout is load-bearing: config.ts derives PROJECT_ROOT by
 # walking four levels up from packages/server/dist and then resolves DATA_DIR
 # as ../data -- i.e. /app/data. Do not flatten this tree.

--- a/docker/webapp.Dockerfile
+++ b/docker/webapp.Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+
+# node:22 -- engines allows "^20.19.0 || >=22.0.0". Not alpine: sql.js ships
+# wasm and there is nothing to gain from musl here.
+FROM node:22-bookworm-slim AS build
+WORKDIR /app/gmail-contact-graph/webapp
+
+# npm ci validates the single root lockfile against EVERY workspace manifest,
+# so all four package.json files must be present before it runs. Copying them
+# ahead of the sources is what keeps the install layer cached across code edits.
+COPY gmail-contact-graph/webapp/package.json gmail-contact-graph/webapp/package-lock.json ./
+COPY gmail-contact-graph/webapp/packages/shared/package.json ./packages/shared/
+COPY gmail-contact-graph/webapp/packages/server/package.json ./packages/server/
+COPY gmail-contact-graph/webapp/packages/client/package.json ./packages/client/
+RUN npm ci
+
+COPY gmail-contact-graph/webapp/ ./
+RUN npm run build
+
+# Production dependencies, installed in the same workspace layout so npm
+# recreates node_modules/@gmail-graph/shared -> ../../packages/shared as a
+# symlink. Copying node_modules without the target of that symlink gives
+# ERR_MODULE_NOT_FOUND at startup.
+FROM node:22-bookworm-slim AS deps
+WORKDIR /app/gmail-contact-graph/webapp
+COPY gmail-contact-graph/webapp/package.json gmail-contact-graph/webapp/package-lock.json ./
+COPY gmail-contact-graph/webapp/packages/shared/package.json ./packages/shared/
+COPY gmail-contact-graph/webapp/packages/server/package.json ./packages/server/
+COPY gmail-contact-graph/webapp/packages/client/package.json ./packages/client/
+RUN npm ci --omit=dev
+
+FROM node:22-bookworm-slim AS runtime
+
+# The directory layout is load-bearing: config.ts derives PROJECT_ROOT by
+# walking four levels up from packages/server/dist and then resolves DATA_DIR
+# as ../data -- i.e. /app/data. Do not flatten this tree.
+WORKDIR /app/gmail-contact-graph/webapp
+
+COPY --from=deps  /app/gmail-contact-graph/webapp/node_modules ./node_modules
+COPY --from=build /app/gmail-contact-graph/webapp/package.json ./
+COPY --from=build /app/gmail-contact-graph/webapp/packages/shared/package.json ./packages/shared/
+COPY --from=build /app/gmail-contact-graph/webapp/packages/server/package.json ./packages/server/
+COPY --from=build /app/gmail-contact-graph/webapp/packages/client/package.json ./packages/client/
+COPY --from=build /app/gmail-contact-graph/webapp/packages/shared/dist ./packages/shared/dist
+COPY --from=build /app/gmail-contact-graph/webapp/packages/server/dist ./packages/server/dist
+# index.ts:40 serves static files from __dirname/../../client/dist. Without
+# this the API works and the page is blank.
+COPY --from=build /app/gmail-contact-graph/webapp/packages/client/dist ./packages/client/dist
+
+COPY docker/webapp-entrypoint.sh /usr/local/bin/webapp-entrypoint.sh
+RUN chmod +x /usr/local/bin/webapp-entrypoint.sh
+
+WORKDIR /app/gmail-contact-graph/webapp/packages/server
+USER node
+ENTRYPOINT ["/usr/local/bin/webapp-entrypoint.sh"]

--- a/docker/webapp.Dockerfile.dockerignore
+++ b/docker/webapp.Dockerfile.dockerignore
@@ -1,0 +1,9 @@
+# See docker/parsers.Dockerfile.dockerignore — this file fully replaces the
+# root .dockerignore for the webapp build, so it must be self-contained.
+*
+!gmail-contact-graph/webapp
+!docker/webapp-entrypoint.sh
+gmail-contact-graph/webapp/node_modules
+gmail-contact-graph/webapp/packages/*/node_modules
+gmail-contact-graph/webapp/packages/*/dist
+**/.git

--- a/gmail-contact-graph/README.md
+++ b/gmail-contact-graph/README.md
@@ -74,3 +74,21 @@ make dev-client     Start React client only
 make clean          Remove node_modules and build output
 make help           Show all commands
 ```
+
+## In Docker
+
+`make run` is what the `webapp` service does:
+
+```bash
+docker compose up -d webapp
+```
+
+Served on <http://127.0.0.1:5000> as usual. Inside the container `HOST` is set
+to `0.0.0.0` — it has to be, or the server would be unreachable from outside the
+container — but the port is published on `127.0.0.1` only, so the webapp is no
+more exposed than it is natively.
+
+The database must already exist; the container refuses to start otherwise and
+points you at the parsers. It is read once at startup, so after a re-parse run
+`docker compose restart webapp`. See
+[Run with Docker](../README.md#run-with-docker).

--- a/gmail-mbox-parser/README.md
+++ b/gmail-mbox-parser/README.md
@@ -103,3 +103,16 @@ make clean-data     Remove generated ranking files
 make clean-db       Remove databases
 make help           Show all commands
 ```
+
+## In Docker
+
+`make fill-db` and `make rankings` together are what the `parser` service runs:
+
+```bash
+docker compose --profile parse up --abort-on-container-failure parser
+```
+
+`docker/parse-entrypoint.sh` deliberately mirrors this Makefile's variable names
+and defaults (`DATA_DIR`, `MBOX_DIR`, `MBOX_FILE`, `RANKINGS_DIR`, `DB_PATH`,
+`USER_EMAIL`) — change a default here and change it there too. See
+[Run with Docker](../README.md#run-with-docker) for the full workflow.


### PR DESCRIPTION
Runs the whole pipeline — mbox parse → rankings → calendar → webapp — with no host toolchain beyond Docker. Additive only: **no Makefile, `.rs` or `.ts` file is touched.**

## Usage

```bash
cp .env.example .env          # set USER_EMAIL
./docker/pipeline.sh          # parse everything, then serve
docker compose up -d webapp   # serve an already-parsed database
```

On Windows run the script from Git Bash, or use the three commands it wraps.

## Design decisions

**Profiles, not `depends_on: required: false`.** `required: false` means "do not fail if absent", not "never start", so the parse services carry a `parse` profile instead. `docker compose up webapp` provably creates no parser container.

**The pipeline is a script, not one compose command.** The webapp reads the database into memory once and writes the whole file back on any exclude-contact action (`server/src/db/index.ts:30-34`), so a webapp left running across a parse silently overwrites fresh data with its stale snapshot. `pipeline.sh` brackets the parse with stop/start, and `parse-entrypoint.sh` refuses to run while `data/.webapp.lock` exists.

**Layered dependency caching, not a cache mount on `target/`.** A cache mount lives only for its `RUN` and lands in no layer, so cache-mounting `target/` would leave a colleague, a cold clone and CI with no cache at all. The registry gets a cache mount; dependencies are cached via manifest stubs.

**Stamp file, not "does contacts.db exist".** An existence check skips forever after a crash mid-parse, ignores a fresh export, and clashes with the hand-restored `contacts.db.bak` files. The stamp (`name+size+mtime+email`) is written only after every step succeeds, guarded by `set -eu` — without it a failed `fill_db` would exit 0 and compose would report success.

**One mbox per run.** `fill_db` takes exactly one file and begins with `DROP TABLE IF EXISTS mails`, so globbing `*.mbox` would silently keep only the last file. A missing `MBOX_FILE` lists what the directory actually contains.

Other details: runtime pinned to `debian:bookworm-slim` matching the builder; `pkg-config`/`libssl-dev` to build and `libssl3` to run (`reqwest` resolves to `native-tls` → `openssl-sys`); all four workspace manifests copied before `npm ci`; `packages/shared/dist` and `packages/client/dist` both shipped; per-Dockerfile ignore files; `HF_API_KEY` never a build arg; `.gitattributes` forces LF so `core.autocrlf=true` cannot ship a `#!/bin/sh\r` shebang.

## Verification

| Check | Result |
|---|---|
| Parity with native | Identical on the same mbox: 3297 messages / 5917 rows / 424 contacts / 124 filtered |
| Image sizes | parsers 143 MB, webapp 373 MB |
| Endpoints | All ten return 200; `/` is 200 `text/html`, catching a missing client bundle |
| Workspace symlink | `@gmail-graph/shared` intact — no `ERR_MODULE_NOT_FOUND` |
| `up webapp` isolation | Only the webapp container is created |
| Lock | Parse refuses while the webapp runs; SIGTERM trap clears the lock |
| Stamp | A mid-pipeline failure writes no stamp → next run re-parses |
| Missing `.env` | Friendly message, non-zero exit, no compose stack trace |
| WAL | No `-wal`/`-shm` left beside `contacts.db` |
| Build cache | No-change rebuild 6 s (26 layers cached); cold ~12 min |

Container parse of a 1.2 GB mbox took 59 s vs 5.6 s native — the WSL2 bind-mount penalty the README now documents. Note that a `fill_db` source edit still costs a full LTO relink (~10 min) because `[profile.release]` sets `lto = true` with `codegen-units = 1`; changing that would mean editing `Cargo.toml`.

## Not in scope

- CI image builds — follow-up PR
- Dev-mode containers (hot reload) — development stays native
- **Upstream bug found while testing:** when zero contacts survive the spam filter, `contacts_filtered` is dropped and never recreated, so the webapp 500s and `generate_rankings` crashes — natively too. Fixing it means calling `setup_filtered_contacts_table` unconditionally, which edits Rust source and belongs in its own PR.
