### PR TITLE
chore(release): prepare 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,60 @@ HTTP API may change in a minor release.
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-08-31
+
+Adds a containerised route through the whole pipeline: with Docker installed,
+an mbox export becomes a served graph in one command, and no Rust or Node
+toolchain has to be present on the host.
+
+### Added
+
+#### Docker
+
+- Two multi-stage images — a parsers image carrying `fill_db`,
+  `generate_rankings` and `fill_events`, and a webapp image carrying the built
+  Express server and client — plus a `docker-compose.yml` that mounts a host
+  data directory into both and puts the parse behind a `parse` profile, so
+  `docker compose up` serves an existing database without re-parsing.
+- `docker/pipeline.sh` runs the whole thing end to end: parse, rankings,
+  calendar, then the webapp on port 5000. `MBOX_FILE`, `USER_EMAIL` and
+  `FORCE_REPARSE` pass through from the shell, matching what the Makefiles
+  already accepted.
+- The parse is idempotent through a `.parse-stamp` recording the inputs it ran
+  against, and the stamp is cleared before `fill_db` drops the mails table, so
+  a failed parse never leaves a broken database looking current. A lock file
+  held by the webapp container keeps a parse from running against a database
+  being served, and is released on a crash as well as a clean exit.
+- The calendar step is genuinely optional: a missing or empty `Calendar`
+  directory is skipped rather than failing the run.
+- The webapp healthcheck queries `/api/contacts`, which touches a table, rather
+  than a status endpoint that answers 200 over a broken database.
+
+#### Tooling
+
+- CI builds both images on every push and pull request and smoke-tests the
+  parse-then-serve path against the committed `sample.mbox` fixture, asserting
+  on the contact list the API returns rather than on status codes alone, and
+  running the parser twice to prove the stamp skip still works.
+
+#### Documentation
+
+- A Docker chapter in the README covering the fixture demo, a real export,
+  rebuilds after a pull, and the Git Bash requirement for `pipeline.sh` on
+  Windows.
+- Quick start now leads with the Google Takeout request, since the export can
+  take hours to arrive, and points at the bundled fixture for anyone who does
+  not want to wait. Dependencies get a collapsible per-platform install guide,
+  including the `pkg-config` and `libssl-dev` that `openssl-sys` needs on Linux.
+- Contributing guidance — no direct pushes to main, Clippy with `-D warnings`,
+  Conventional Commits, never commit a real export — plus contact channels and
+  a link to the project write-up and its video walkthrough.
+
+### Changed
+
+- The three npm packages and three Rust crates now declare 0.2.0, tracking the
+  release tag.
+
 ## [0.1.0] - 2026-08-20
 
 First release: the pipeline runs end to end on a clean machine, from a Google
@@ -83,5 +137,6 @@ Takeout export to an interactive graph in the browser.
   Everything else in the pipeline is deterministic.
 - Requires Rust 1.87+ and Node.js 20.19+ (or 22+).
 
-[Unreleased]: https://github.com/yegormishchuk/gmail-contact-graph/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/yegormishchuk/gmail-contact-graph/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/yegormishchuk/gmail-contact-graph/releases/tag/v0.2.0
 [0.1.0]: https://github.com/yegormishchuk/gmail-contact-graph/releases/tag/v0.1.0

--- a/calendar-parser/Cargo.lock
+++ b/calendar-parser/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calendar-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "dotenvy",

--- a/calendar-parser/Cargo.toml
+++ b/calendar-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calendar-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 # This crate's own dependency graph only needs 1.71, but it is documented and
 # tested as one pipeline with gmail-mbox-parser, so it declares the same floor.

--- a/gmail-contact-graph/webapp/package-lock.json
+++ b/gmail-contact-graph/webapp/package-lock.json
@@ -5679,7 +5679,7 @@
     },
     "packages/client": {
       "name": "@gmail-graph/client",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@gmail-graph/shared": "*",
@@ -5698,7 +5698,7 @@
     },
     "packages/server": {
       "name": "@gmail-graph/server",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@gmail-graph/shared": "*",
@@ -5717,7 +5717,7 @@
     },
     "packages/shared": {
       "name": "@gmail-graph/shared",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/gmail-contact-graph/webapp/packages/client/package.json
+++ b/gmail-contact-graph/webapp/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmail-graph/client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/gmail-contact-graph/webapp/packages/server/package.json
+++ b/gmail-contact-graph/webapp/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmail-graph/server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/gmail-contact-graph/webapp/packages/shared/package.json
+++ b/gmail-contact-graph/webapp/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmail-graph/shared",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/gmail-mbox-parser/Cargo.lock
+++ b/gmail-mbox-parser/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "gmail-mbox-parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "base64",
  "charset",

--- a/gmail-mbox-parser/Cargo.toml
+++ b/gmail-mbox-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gmail-mbox-parser"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 # 1.83 comes from the committed Cargo.lock (icu_* 2.1, pulled in through
 # reqwest -> url -> idna); 1.87 comes from our own use of `is_multiple_of` in

--- a/gmail-mbox-parser/tools/Cargo.lock
+++ b/gmail-mbox-parser/tools/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ranking_tools"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "rusqlite",
 ]

--- a/gmail-mbox-parser/tools/Cargo.toml
+++ b/gmail-mbox-parser/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ranking_tools"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 # Only needs 1.65 on its own, but `make process-all` builds it alongside
 # fill_db, so it declares the same floor as the parser it ships with.


### PR DESCRIPTION
Release prep for v0.2.0 — no functional change.

- `CHANGELOG.md` gains a 0.2.0 entry covering everything since v0.1.0: the Docker images and compose stack, the stamp/lock idempotency, the optional calendar step, the healthcheck that touches a table, the CI job that builds both images and runs parse → serve against the committed fixture, and the README work (Docker chapter, Takeout-first quick start, per-platform install guide, contributing guidance, write-up link).
- The three npm packages and three Rust crates move to 0.2.0, with their lock files, the way 0.1.0 was stamped before its tag.

The entry describes the Docker stack as it ships rather than replaying the five regression fixes it took to get there — none of that code was in a release, so there is nothing for a reader upgrading from 0.1.0 to act on.