### PR TITLE
chore(release): prepare 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ HTTP API may change in a minor release.
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-09-01
+
+A documentation release: the Docker chapter now teaches one route instead of
+two.
+
 ### Removed
 
 - `docker/pipeline.sh`. It only wrapped three `docker compose` commands, and
@@ -147,6 +152,7 @@ Takeout export to an interactive graph in the browser.
   Everything else in the pipeline is deterministic.
 - Requires Rust 1.87+ and Node.js 20.19+ (or 22+).
 
-[Unreleased]: https://github.com/yegormishchuk/gmail-contact-graph/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/yegormishchuk/gmail-contact-graph/compare/v0.2.1...HEAD
+[0.2.1]: https://github.com/yegormishchuk/gmail-contact-graph/releases/tag/v0.2.1
 [0.2.0]: https://github.com/yegormishchuk/gmail-contact-graph/releases/tag/v0.2.0
 [0.1.0]: https://github.com/yegormishchuk/gmail-contact-graph/releases/tag/v0.1.0

--- a/calendar-parser/Cargo.lock
+++ b/calendar-parser/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "calendar-parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "dotenvy",

--- a/calendar-parser/Cargo.toml
+++ b/calendar-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calendar-parser"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 # This crate's own dependency graph only needs 1.71, but it is documented and
 # tested as one pipeline with gmail-mbox-parser, so it declares the same floor.

--- a/gmail-contact-graph/webapp/package-lock.json
+++ b/gmail-contact-graph/webapp/package-lock.json
@@ -5679,7 +5679,7 @@
     },
     "packages/client": {
       "name": "@gmail-graph/client",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@gmail-graph/shared": "*",
@@ -5698,7 +5698,7 @@
     },
     "packages/server": {
       "name": "@gmail-graph/server",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@gmail-graph/shared": "*",
@@ -5717,7 +5717,7 @@
     },
     "packages/shared": {
       "name": "@gmail-graph/shared",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.9.3"

--- a/gmail-contact-graph/webapp/packages/client/package.json
+++ b/gmail-contact-graph/webapp/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmail-graph/client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/gmail-contact-graph/webapp/packages/server/package.json
+++ b/gmail-contact-graph/webapp/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmail-graph/server",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/gmail-contact-graph/webapp/packages/shared/package.json
+++ b/gmail-contact-graph/webapp/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gmail-graph/shared",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/gmail-mbox-parser/Cargo.lock
+++ b/gmail-mbox-parser/Cargo.lock
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "gmail-mbox-parser"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "base64",
  "charset",

--- a/gmail-mbox-parser/Cargo.toml
+++ b/gmail-mbox-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gmail-mbox-parser"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 # 1.83 comes from the committed Cargo.lock (icu_* 2.1, pulled in through
 # reqwest -> url -> idna); 1.87 comes from our own use of `is_multiple_of` in

--- a/gmail-mbox-parser/tools/Cargo.lock
+++ b/gmail-mbox-parser/tools/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "ranking_tools"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "rusqlite",
 ]

--- a/gmail-mbox-parser/tools/Cargo.toml
+++ b/gmail-mbox-parser/tools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ranking_tools"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 # Only needs 1.65 on its own, but `make process-all` builds it alongside
 # fill_db, so it declares the same floor as the parser it ships with.


### PR DESCRIPTION
Re-opens the release prep against `main`. #10 was stacked on #9 and got merged
into `refactor/drop-pipeline-sh` rather than `main`, so the version bump never
reached `main` — this is the same commit (`bf9a1af`), cherry-picked on top of
current `main`.

The only change since v0.2.0 is #9: the Docker chapter teaches the three
compose commands directly instead of `docker/pipeline.sh`. No code, schema or
API changed, so this is a patch.

## What changed

- CHANGELOG: the Unreleased entry becomes `[0.2.1] - 2026-09-01`, with the
  compare/tag links updated.
- Versions move to 0.2.1 across the three npm packages and three crates
  (manifests and lockfiles), the way 0.2.0 was stamped before its tag.

Tag `v0.2.1` after the merge.
